### PR TITLE
fix(avatar): normalize requests and guard transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist-server/
 .idea/workspace.xml
 .idea/usage.statistics.xml
 .idea/shelf
+.playwright-mcp/
 
 # deps
 node_modules/

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ GET /avatar/205e460b479e2e5b48aec07710c08d50?s=128
 
 ### 🔹 `GET /avatar?email=<email>`
 
-Fetches the avatar by raw email (safely hashed server-side). If the email is invalid, it falls back to `email@example.com`.
+Fetches the avatar by raw email (safely normalized and hashed server-side). If the email is missing or invalid, it falls back to `email@example.com`.
 
 **Example:**
 
@@ -89,11 +89,13 @@ Automatically returns the most optimized format:
 - `image/webp` (fallback)
 - Original JPEG (fallback fallback 🙃)
 
-Based on the browser’s `Accept` header:
+Based on the browser’s `Accept` header, including quality values like `q=0.9`:
 
 ```http
 Accept: image/avif,image/webp,image/*,*/*
 ```
+
+Large or unsupported source images may be streamed back in their original format to protect Worker memory and CPU limits.
 
 ## 📦 Caching Strategy
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -39,7 +39,7 @@ GET /avatar/205e460b479e2e5b48aec07710c08d50?s=128
 
 ### 🔹 `GET /avatar?email=<email>`
 
-**raw email** でアバターを取得（サーバー側で安全にハッシュ化）。無効なメールの場合、`email@example.com` にフォールバック。
+**raw email** でアバターを取得（サーバー側で安全に正規化してハッシュ化）。メールが未指定または無効な場合、`email@example.com` にフォールバック。
 
 **例：**
 
@@ -62,11 +62,13 @@ GET /avatar?email=email@example.com&size=256
 - `image/webp`（フォールバック）
 - 元の **JPEG**（最終フォールバック 🙃）
 
-ブラウザの `Accept` ヘッダーに基づいて判定：
+ブラウザの `Accept` ヘッダーに基づいて判定し、`q=0.9` のような品質値にも対応：
 
 ```http
 Accept: image/avif,image/webp,image/*,*/*
 ```
+
+Worker のメモリと CPU 制限を守るため、大きすぎる画像や未対応の元形式は元の形式のままストリーミングされる場合があります。
 
 ## 📦 キャッシュ戦略（Caching Strategy）
 

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -39,7 +39,7 @@ GET /avatar/205e460b479e2e5b48aec07710c08d50?s=128
 
 ### 🔹 `GET /avatar?email=<email>`
 
-通过**原始邮箱**获取头像（服务器端安全地进行哈希）。若邮箱无效，将回退到 `email@example.com`。
+通过**原始邮箱**获取头像（服务器端安全地规范化并进行哈希）。若邮箱缺失或无效，将回退到 `email@example.com`。
 
 **示例：**
 
@@ -62,11 +62,13 @@ GET /avatar?email=email@example.com&size=256
 - `image/webp`（次优回退）
 - 原始 **JPEG**（兜底中的兜底 🙃）
 
-根据浏览器的 `Accept` 请求头进行协商：
+根据浏览器的 `Accept` 请求头进行协商，支持 `q=0.9` 这样的质量权重：
 
 ```http
 Accept: image/avif,image/webp,image/*,*/*
 ```
+
+为保护 Worker 的内存和 CPU 限制，过大的图片或不支持的源格式可能会以原始格式流式返回。
 
 ## 📦 缓存策略（Caching Strategy）
 

--- a/src/components/api-docs.tsx
+++ b/src/components/api-docs.tsx
@@ -81,7 +81,7 @@ const ApiDocs = ({ config }: ApiDocsProps) => {
           <ul>
             <li>
               <strong>&lt;email&gt;</strong>
-              : The plain email address to resolve a Gravatar (if the email is invalid, we will use `email@example.com` as fallback).
+              : The plain email address to resolve a Gravatar. It is trimmed and lowercased before hashing; invalid or missing values fall back to `email@example.com`.
             </li>
           </ul>
         </article>
@@ -143,7 +143,10 @@ const ApiDocs = ({ config }: ApiDocsProps) => {
           based on the browser’s
           <code> Accept </code>
           {' '}
-          header. JPEG is used as a fallback if neither is supported.
+          header, including quality values such as
+          {' '}
+          <code>q=0.9</code>
+          . The original image format is used as a fallback if neither is supported or the requested image is too large to safely transform at the edge.
         </p>
         <pre aria-label="Accept header example">
           <code>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import ApiDocs from './components/api-docs'
 import { loadConfig } from './config'
 import { renderer } from './renderer'
 import { fetchGravatar } from './utils'
+import { normalizeEmail, resolveLookupEmail } from './utils/avatarInput'
 
 const app = new Hono<{ Bindings: EnvRecord }>()
 
@@ -82,7 +83,11 @@ app.get('/avatar/me', async (c) => {
   if (hash === undefined && config.api.meEmail === undefined) {
     return c.text('Set `ME_EMAIL` or `ME_HASH` (legacy: `HASH`) in your Cloudflare Worker environment variables to enable this endpoint.')
   }
-  const resolvedHash = hash ?? await sha256(config.api.meEmail ?? '')
+  const normalizedEmail = normalizeEmail(config.api.meEmail)
+  if (hash === undefined && normalizedEmail === undefined) {
+    return c.text('Set a valid `ME_EMAIL` or `ME_HASH` (legacy: `HASH`) in your Cloudflare Worker environment variables to enable this endpoint.', 500)
+  }
+  const resolvedHash = hash ?? await sha256(normalizedEmail ?? '')
   if (resolvedHash === null) {
     return c.text('Internal Server Error', 500)
   }
@@ -103,7 +108,7 @@ app.get('/avatar', async (c) => {
   if (!config.api.allowRawEmail) {
     return c.text('Raw email lookup is disabled on this deployment.', 403)
   }
-  const emailValue = c.req.query('email') ?? 'email@example.com'
+  const emailValue = resolveLookupEmail(c.req.query('email'))
   const hash = await sha256(emailValue)
 
   if (hash === null) {

--- a/src/utils/avatarInput.ts
+++ b/src/utils/avatarInput.ts
@@ -1,0 +1,104 @@
+export const FALLBACK_EMAIL = 'email@example.com'
+
+const MIME_PRIORITY = ['image/avif', 'image/webp', 'image/jpeg', 'image/png'] as const
+const WILDCARD_PRIORITY = ['image/webp', 'image/jpeg', 'image/png'] as const
+
+export type PreferredImageMime = (typeof MIME_PRIORITY)[number]
+
+const isValidEmail = (email: string): boolean => {
+  if ([...email].some(char => char.trim().length === 0)) {
+    return false
+  }
+
+  const parts = email.split('@')
+  if (parts.length !== 2 || parts.some(part => part.length === 0)) {
+    return false
+  }
+
+  const [, domain] = parts
+  return domain.split('.').every(part => part.length > 0) && domain.includes('.')
+}
+
+export const normalizeEmail = (email: string | undefined): string | undefined => {
+  const normalized = email?.trim().toLowerCase()
+  if (normalized === undefined || normalized.length === 0) {
+    return undefined
+  }
+  return isValidEmail(normalized) ? normalized : undefined
+}
+
+export const resolveLookupEmail = (email: string | undefined): string => {
+  return normalizeEmail(email) ?? FALLBACK_EMAIL
+}
+
+interface AcceptedMime {
+  mime: PreferredImageMime
+  q: number
+  priority: number
+}
+
+const parseAcceptPart = (part: string): { mediaRange: string, q: number } | undefined => {
+  const [rawMediaRange, ...params] = part.split(';').map(value => value.trim())
+  const mediaRange = rawMediaRange?.toLowerCase()
+  if (mediaRange === undefined || mediaRange.length === 0) {
+    return undefined
+  }
+
+  const qParam = params.find(param => param.toLowerCase().startsWith('q='))
+  const q = qParam === undefined ? 1 : Number.parseFloat(qParam.slice(2))
+  if (!Number.isFinite(q) || q < 0) {
+    return undefined
+  }
+
+  return { mediaRange, q: Math.min(q, 1) }
+}
+
+const addAcceptedMime = (
+  accepted: Map<PreferredImageMime, AcceptedMime>,
+  mime: PreferredImageMime,
+  q: number,
+) => {
+  const priority = MIME_PRIORITY.indexOf(mime)
+  const existing = accepted.get(mime)
+  if (existing === undefined || q > existing.q) {
+    accepted.set(mime, { mime, q, priority })
+  }
+}
+
+export const parseAcceptHeader = (acceptHeader: string | undefined): PreferredImageMime[] => {
+  if (acceptHeader === undefined || acceptHeader.trim().length === 0) {
+    return ['image/webp']
+  }
+
+  const accepted = new Map<PreferredImageMime, AcceptedMime>()
+  const rejected = new Set<PreferredImageMime>()
+  for (const part of acceptHeader.split(',')) {
+    const parsed = parseAcceptPart(part)
+    if (parsed === undefined) {
+      continue
+    }
+
+    const explicitMime = MIME_PRIORITY.find(mime => mime === parsed.mediaRange)
+    if (explicitMime !== undefined) {
+      if (parsed.q === 0) {
+        accepted.delete(explicitMime)
+        rejected.add(explicitMime)
+        continue
+      }
+      addAcceptedMime(accepted, explicitMime, parsed.q)
+      continue
+    }
+
+    if (parsed.mediaRange === 'image/*' || parsed.mediaRange === '*/*') {
+      for (const mime of WILDCARD_PRIORITY) {
+        if (!rejected.has(mime) && parsed.q > 0) {
+          addAcceptedMime(accepted, mime, parsed.q)
+        }
+      }
+    }
+  }
+
+  return [...accepted.values()]
+    .sort((a, b) => b.q - a.q || a.priority - b.priority)
+    .map(({ mime }) => mime)
+}

--- a/src/utils/fetchGravatar.ts
+++ b/src/utils/fetchGravatar.ts
@@ -1,8 +1,67 @@
 import type { Context } from 'hono'
+import { parseAcceptHeader } from './avatarInput'
 import { cacheHeaders } from './cacheHeader'
 import { imgProcessor } from './imgProcessor'
 
-const ALLOWED_MIMES = ['image/avif', 'image/webp', 'image/jpeg', 'image/png']
+const TRANSFORM_MIMES = ['image/avif', 'image/webp']
+const TRANSFORM_SOURCE_MIMES = ['image/jpeg', 'image/png']
+const MAX_TRANSFORM_BYTES = 4 * 1024 * 1024
+const MAX_TRANSFORM_PIXELS = 1024 * 1024
+const UPSTREAM_TIMEOUT_MS = 10_000
+
+const getContentType = (headers: Headers): string => {
+  return headers.get('Content-Type')?.split(';')[0]?.trim().toLowerCase() ?? 'image/jpeg'
+}
+
+const shouldTransformImage = (
+  contentType: string,
+  contentLength: string | null,
+  acceptTypes: string[],
+  size: number,
+) => {
+  if (!TRANSFORM_SOURCE_MIMES.includes(contentType)) {
+    return false
+  }
+  if (!acceptTypes.some(type => TRANSFORM_MIMES.includes(type))) {
+    return false
+  }
+  if (size * size > MAX_TRANSFORM_PIXELS) {
+    return false
+  }
+  if (contentLength !== null) {
+    const bytes = Number.parseInt(contentLength, 10)
+    if (Number.isFinite(bytes) && bytes > MAX_TRANSFORM_BYTES) {
+      return false
+    }
+  }
+  return true
+}
+
+const proxiedImageResponse = (
+  data: BodyInit | null,
+  status: number,
+  hash: string,
+  config: SiteConfig,
+  contentType: string,
+) => {
+  return new Response(data, {
+    status,
+    headers: {
+      ...cacheHeaders(status >= 200 && status < 300, hash, config),
+      'Content-Type': contentType,
+    },
+  })
+}
+
+const upstreamErrorResponse = () => {
+  return new Response('Upstream Error', {
+    status: 502,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  })
+}
 
 export const fetchGravatar = async (
   c: Context,
@@ -22,11 +81,7 @@ export const fetchGravatar = async (
   const initials = c.req.query('initials')
   const name = c.req.query('name')
 
-  const acceptTypeString = c.req.header('Accept')
-  const acceptTypes = acceptTypeString !== undefined
-    ? acceptTypeString.split(',').map(t => t.trim())
-    : ['image/webp']
-  const normalizedAccept = acceptTypes.filter(type => ALLOWED_MIMES.includes(type))
+  const normalizedAccept = parseAcceptHeader(c.req.header('Accept'))
 
   const params = new URLSearchParams({
     s: `${size}`,
@@ -42,27 +97,38 @@ export const fetchGravatar = async (
 
   const gravatarUrl = `https://www.gravatar.com/avatar/${hash}?${params.toString()}`
 
-  const res = await fetch(gravatarUrl, {
-    cf: {
-      cacheEverything: true,
-      cacheTtlByStatus: {
-        '200-299': config.cache.edgeTtlOk,
-        '404': config.cache.edgeTtl404,
+  let res: Response
+  try {
+    res = await fetch(gravatarUrl, {
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+      cf: {
+        cacheEverything: true,
+        cacheTtlByStatus: {
+          '200-299': config.cache.edgeTtlOk,
+          '404': config.cache.edgeTtl404,
+        },
       },
-    },
-  })
-
-  if (!res.ok) {
-    return c.notFound()
+    })
+  }
+  catch {
+    return upstreamErrorResponse()
   }
 
-  const contentType = res.headers.get('Content-Type') ?? 'image/jpeg'
-  const imageBuffer = await res.arrayBuffer()
-  const { data, mime } = await imgProcessor(imageBuffer, contentType, normalizedAccept)
-  return new Response(data, {
-    headers: {
-      ...cacheHeaders(res.ok, hash, config),
-      'Content-Type': mime,
-    },
-  })
+  if (!res.ok) {
+    return proxiedImageResponse('Not Found', 404, hash, config, 'text/plain; charset=utf-8')
+  }
+
+  const contentType = getContentType(res.headers)
+  if (!shouldTransformImage(contentType, res.headers.get('Content-Length'), normalizedAccept, size)) {
+    return proxiedImageResponse(res.body, res.status, hash, config, contentType)
+  }
+
+  try {
+    const imageBuffer = await res.arrayBuffer()
+    const { data, mime } = await imgProcessor(imageBuffer, contentType, normalizedAccept)
+    return proxiedImageResponse(data, res.status, hash, config, mime)
+  }
+  catch {
+    return upstreamErrorResponse()
+  }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export { normalizeEmail, parseAcceptHeader, resolveLookupEmail } from './avatarInput'
 export { fetchGravatar } from './fetchGravatar'


### PR DESCRIPTION
## 📌 Description

Fixes runtime avatar request handling found during the local audit: raw email lookups are normalized and validated before hashing, upstream 404 responses now keep documented cache headers, Accept negotiation handles q values and wildcards, and image transforms are guarded to avoid buffering unsafe responses.

### 🔍 Feature Changes

- [x] API update
- [x] Other: documented request normalization and transform fallback behavior

### 🛠 Bug Fixes

- [x] Fixed issue: 404 avatar responses skipped cache headers
- [x] Improved error handling
- [x] Performance fix
- [x] Other: invalid/missing raw emails now fall back consistently

### ✅ Checklist

1. Feature Updates:

- [x] Code follows project coding style.
- [x] Tested in a Hono environment.
- [x] Relevant documentation is updated.

2. Bug Fixes:

- [x] Bug has been reproduced and verified.
- [x] Fix does not introduce new issues.
- [ ] Added necessary tests. No test runner exists in this repository; verified with lint, typecheck, build, and local HTTP requests.

### 📝 Steps to Reproduce (before fix)

- Request `/avatar?email=email@example.com&size=64` for a missing avatar and observe the 404 response lacked documented cache headers.
- Request `/avatar?email=INVALID` and observe the raw value was hashed instead of falling back to `email@example.com`.
- Request with `Accept: image/webp;q=0.9,image/avif;q=0` and observe q values were not parsed.

### 💬 Additional Notes

Checks run:

- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `git diff --check`
- Local HTTP verification against `pnpm dev --host 127.0.0.1 --port 4174` for 404 cache headers, invalid/missing email fallback, Accept q negotiation, and large-image original-format fallback.

Review:

- Ran a focused subagent review for avatar request handling. Fixed its blocking finding by making transform read/encode failures return a non-cacheable 502 instead of an empty cached 2xx response.

### 📸 Screenshots (if applicable)

Not applicable; API/runtime behavior only.
