### PR TITLE
ci: classify release notes by title

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -217,7 +217,8 @@ jobs:
                 }
 
                 const match = trimmed.match(conventionalTitlePattern);
-                const category = match
+                const shouldUseConventionalFallback = !currentCategory || currentCategory === miscCategory;
+                const category = match && shouldUseConventionalFallback
                   ? categoryByType.get(match[1].toLowerCase())
                   : undefined;
                 (category || currentCategory || miscCategory).lines.push(trimmed);

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -143,6 +143,92 @@ jobs:
             const raw = (res.data.body || "").trim();
             const generated = raw.replace(/^<!--[\s\S]*?-->\s*/m, "").trim();
 
+            const categorizeByConventionalTitle = (notes) => {
+              const conventionalCategories = [
+                {
+                  title: "### 🚀 Features / 新功能",
+                  types: new Set(["feat"]),
+                  lines: [],
+                },
+                {
+                  title: "### 🐛 Bug Fixes / 修复",
+                  types: new Set(["fix"]),
+                  lines: [],
+                },
+                {
+                  title: "### 🛠️ Improvements / 改进",
+                  types: new Set(["perf", "refactor"]),
+                  lines: [],
+                },
+                {
+                  title: "### 📖 Documentation / 文档更新",
+                  types: new Set(["docs"]),
+                  lines: [],
+                },
+                {
+                  title: "### 📦 Dependencies / 依赖更新",
+                  types: new Set(["deps"]),
+                  lines: [],
+                },
+                {
+                  title: "### 🧰 Internal / 内部变更",
+                  types: new Set(["build", "chore", "ci", "test"]),
+                  lines: [],
+                },
+                {
+                  title: "### 💥 Breaking Changes / 破坏性变更",
+                  types: new Set([]),
+                  lines: [],
+                },
+                {
+                  title: "### 🎨 UI UX & Styling / UI UX & 样式",
+                  types: new Set(["style"]),
+                  lines: [],
+                },
+              ];
+              const miscCategory = {
+                title: "### 🔄 Miscellaneous / 其他变更",
+                lines: [],
+              };
+              const categoryByType = new Map(
+                conventionalCategories.flatMap((category) =>
+                  [...category.types].map((type) => [type, category])
+                )
+              );
+              const categoryByHeading = new Map(
+                conventionalCategories.map((category) => [
+                  category.title.replace(/^###\s+/, "").toLowerCase(),
+                  category,
+                ])
+              );
+              categoryByHeading.set("miscellaneous / 其他变更", miscCategory);
+              const headingPattern = /^#{2,4}\s+/;
+              const conventionalTitlePattern = /^-\s+([a-z]+)(?:\([^)]+\))?!?:\s+/i;
+              let currentCategory;
+
+              for (const line of notes.split("\n")) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                if (headingPattern.test(trimmed)) {
+                  currentCategory = categoryByHeading.get(
+                    trimmed.replace(headingPattern, "").trim().toLowerCase()
+                  );
+                  continue;
+                }
+
+                const match = trimmed.match(conventionalTitlePattern);
+                const category = match
+                  ? categoryByType.get(match[1].toLowerCase())
+                  : undefined;
+                (category || currentCategory || miscCategory).lines.push(trimmed);
+              }
+
+              return [...conventionalCategories, miscCategory]
+                .filter((category) => category.lines.length > 0)
+                .map((category) => `${category.title}\n${category.lines.join("\n")}`)
+                .join("\n\n");
+            };
+
             let changelog = generated;
 
             // 1) Drop "What's Changed" heading (any heading level)
@@ -171,11 +257,27 @@ jobs:
               (_line, title, user, url, prNumber) => `- ${title} ([#${prNumber}](${url})) by ${user}`
             );
 
-            // 7) Tidy whitespace
+            // 7) Re-bucket unlabeled generated notes by Conventional Commit title.
+            changelog = categorizeByConventionalTitle(changelog);
+
+            // 8) Tidy whitespace
             changelog = changelog.replace(/\n{3,}/g, "\n\n").trim();
 
-            const releaseBody = generated
+            let releaseBody = generated
               .replace(/^\s*#+\s+What's Changed\s*\n+/im, "")
+              .replace(
+                /^\s*#+\s+New Contributors\s*\n[\s\S]*?(?=^\s*#+\s|\s*$)/im,
+                ""
+              )
+              .replace(/^\s*\*\*Full Changelog\*\*:[^\n]*\n?/im, "")
+              .replace(/^####\s+/gm, "### ")
+              .replace(/^##\s+/gm, "### ")
+              .replace(/^\*\s+/gm, "- ")
+              .replace(
+                /^- (.+?)\s+by\s+(@[A-Za-z0-9-]+)\s+in\s+(https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/(\d+))\s*$/gm,
+                (_line, title, user, url, prNumber) => `- ${title} ([#${prNumber}](${url})) by ${user}`
+              );
+            releaseBody = categorizeByConventionalTitle(releaseBody)
               .replace(/\n{3,}/g, "\n\n")
               .trim();
             const body = [manualSummary, releaseBody].filter(Boolean).join("\n\n");


### PR DESCRIPTION
## ✨ Features Updates && 🐛 Bug Fix && 🛠 Code Refactor && 📦 Dependency Update

### 📌 Description

Fix Prepare Release PR release-note classification when GitHub generated notes put unlabeled PRs under Miscellaneous. The workflow now uses Conventional Commit title prefixes as a fallback for unlabeled entries, while preserving explicit label-based headings from `.github/release.yml`.

### 🔄 Refactor Changes

- [x] Other: classify unlabeled release notes by PR title prefix

### 🛠 Bug Fixes

- [x] Fixed issue: `fix`, `refactor`, `ci`, and `chore` PRs were all landing under Miscellaneous when PR labels were absent
- [x] Fix does not override explicit label categories such as Breaking Changes or Bug Fixes

### ✅ Checklist

1. Feature Updates:

- [x] Code follows project coding style.
- [x] Relevant documentation is updated or not needed.

2. Bug Fixes:

- [x] Bug has been reproduced and verified.
- [x] Fix does not introduce new issues.

3. Code Refactor:

- [x] No breaking changes introduced.
- [x] Documentation updated if necessary.

### 📝 Steps to Reproduce (before fix)

Run Prepare Release PR for `v1.1.0-beta.0` without PR labels on the included changes. Generated notes place `ci`, `fix`, `refactor`, and `chore` entries under Miscellaneous.

### 💬 Additional Notes

Automated checks run locally: `pnpm run lint`, `git diff --check`.

Manual validation: ran the embedded categorization logic against sample notes to confirm `fix` -> Bug Fixes, `refactor` -> Improvements, `ci` / `chore` -> Internal, and explicit label headings remain preserved.

Subagent review: found the initial implementation overrode label categories; fixed before opening this PR.

### 📸 Screenshots (if applicable)

Not applicable.
