### PR TITLE
ci: harden release detection

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -85,34 +85,64 @@ jobs:
               return;
             }
 
-            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner,
-              repo,
-              commit_sha: sha,
-            });
-
             const releaseTitlePattern = /^release:\s+v([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$/;
-            const releasePr = prs.data.find((pr) => {
+            const releaseBranchPattern = /^release\/v([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$/;
+            const findReleasePr = (pulls) => pulls.find((pr) => {
               const title = pr.title || "";
               const branch = pr.head?.ref || "";
-              return releaseTitlePattern.test(title)
-                && /^release\/v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(branch);
+              return releaseTitlePattern.test(title) || releaseBranchPattern.test(branch);
             });
 
+            const listAssociatedPrs = async () => {
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: sha,
+              });
+              return prs.data;
+            };
+
+            let releasePr = findReleasePr(await listAssociatedPrs());
+            let commitMessage = "";
+            let subjectMatch;
             if (!releasePr) {
-              core.setOutput("is_release", "false");
-              return;
+              const commit = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: sha,
+              });
+              commitMessage = commit.data.commit?.message || "";
+              const subject = commitMessage.split("\n")[0]?.trim() || "";
+              subjectMatch = subject.match(releaseTitlePattern);
+              if (!subjectMatch) {
+                core.setOutput("is_release", "false");
+                return;
+              }
+
+              core.info("Release commit subject matched. Retrying associated PR lookup for release notes.");
+              for (let attempt = 1; attempt <= 5 && !releasePr; attempt += 1) {
+                await new Promise((resolve) => setTimeout(resolve, 3000));
+                releasePr = findReleasePr(await listAssociatedPrs());
+              }
             }
 
-            const titleMatch = (releasePr.title || "").match(releaseTitlePattern);
-            const branchMatch = (releasePr.head?.ref || "").match(/^release\/v([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$/);
-            const version = titleMatch?.[1] || branchMatch?.[1];
+            let version = "";
+            let body = "";
+            if (releasePr) {
+              const titleMatch = (releasePr.title || "").match(releaseTitlePattern);
+              const branchMatch = (releasePr.head?.ref || "").match(releaseBranchPattern);
+              version = titleMatch?.[1] || branchMatch?.[1] || "";
+              body = (releasePr.body || "").trim();
+            }
+            else {
+              version = subjectMatch[1];
+              body = commitMessage.split("\n").slice(1).join("\n").trim();
+            }
+
             if (!version) {
-              core.setFailed(`Could not parse release version from PR #${releasePr.number}`);
+              core.setFailed(`Could not parse release version for commit ${sha}`);
               return;
             }
-
-            let body = (releasePr.body || "").trim();
 
             const notesMatch = body.match(/##\s*Release notes\s*([\s\S]*)/i);
             if (notesMatch) body = notesMatch[1].trim();


### PR DESCRIPTION
## ✨ Features Updates && 🐛 Bug Fix && 🛠 Code Refactor && 📦 Dependency Update

### 📌 Description

Harden the Create GitHub Release workflow so squash-merged release PRs are detected reliably. The previous run triggered after `release: v1.1.0-beta.0`, but skipped all release steps because the release PR was not detected in time.

### 🛠 Bug Fixes

- [x] Fixed issue: release squash commits could be treated as non-release commits
- [x] Other: retry associated PR lookup when the commit subject is already `release: v...`
- [x] Other: fall back to the release commit subject/body if GitHub's associated PR lookup is still unavailable

### ✅ Checklist

1. Bug Fixes:

- [x] Bug has been reproduced and verified.
- [x] Fix does not introduce new issues.

3. Code Refactor:

- [x] No breaking changes introduced.
- [x] Documentation updated if necessary.

### 📝 Steps to Reproduce (before fix)

Merge the generated release PR `release: v1.1.0-beta.0`. The Create GitHub Release workflow runs on the push to `main`, but `Detect release PR` sets `is_release=false`, so tag and release creation are skipped.

### 💬 Additional Notes

Automated checks run locally: `pnpm run lint`, `git diff --check`.

Manual validation: simulated release PR and ordinary commit matching. `release: v1.1.0-beta.0` resolves to `1.1.0-beta.0`; ordinary `ci:` commits do not match.

Subagent review: no blocking findings. The only noted risk is that any PR deliberately named `release: vX.Y.Z` or branch `release/vX.Y.Z` can trigger release detection, with the existing package version check still guarding most accidental misuse.

### 📸 Screenshots (if applicable)

Not applicable.
