### PR TITLE
ci: allow manual release tag creation

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Existing tag version to publish, with or without the v prefix
+        description: Release version to publish, with or without the v prefix
         required: true
         type: string
 
@@ -169,7 +169,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Checkout existing release tag
-        if: steps.detect.outputs.is_release == 'true' && steps.detect.outputs.source != 'main'
+        if: steps.detect.outputs.is_release == 'true' && steps.detect.outputs.source == 'tag'
         shell: bash
         run: |
           set -euo pipefail
@@ -236,7 +236,7 @@ jobs:
           fi
 
       - name: Create tag
-        if: steps.detect.outputs.is_release == 'true' && steps.detect.outputs.source == 'main' && steps.tag_exists.outputs.exists != 'true'
+        if: steps.detect.outputs.is_release == 'true' && steps.detect.outputs.source != 'tag' && steps.tag_exists.outputs.exists != 'true'
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## ✨ Features Updates && 🐛 Bug Fix && 🛠 Code Refactor && 📦 Dependency Update

### 📌 Description

Allow manual Create GitHub Release dispatches to publish a release version even when the tag is missing. This is needed to recover `v1.1.0-beta.0`, where the automatic release run triggered before release detection was fixed and skipped tag/release creation.

### 🛠 Bug Fixes

- [x] Fixed issue: manual dispatch failed by trying to checkout a missing tag before it could create it
- [x] Other: keep tag push events checking out the existing tag
- [x] Other: allow manual/main release paths to create the tag when it does not exist

### ✅ Checklist

2. Bug Fixes:

- [x] Bug has been reproduced and verified.
- [x] Fix does not introduce new issues.

3. Code Refactor:

- [x] No breaking changes introduced.

### 📝 Steps to Reproduce (before fix)

Run Create GitHub Release manually with `version=1.1.0-beta.0` while tag `v1.1.0-beta.0` is missing. The workflow fails at `Checkout existing release tag`.

### 💬 Additional Notes

Automated checks run locally: `pnpm run lint`, `git diff --check`.

Self-review focus: the tag event path still checks out the tag; manual dispatch now uses the selected ref and the existing package-version check before creating a missing tag.

### 📸 Screenshots (if applicable)

Not applicable.
