### PR TITLE
ci: reuse release PR notes on manual publish

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -59,6 +59,22 @@ jobs:
               }
               catch (error) {
                 core.info(`No existing GitHub Release found for v${version}; it will be created if needed.`);
+                const releaseTitle = `release: v${version}`;
+                const releaseBranch = `release/v${version}`;
+                const pulls = await github.paginate(github.rest.pulls.list, {
+                  owner,
+                  repo,
+                  state: "closed",
+                  base: "main",
+                  per_page: 100,
+                });
+                const releasePr = pulls.find((pr) =>
+                  pr.merged_at && (pr.title === releaseTitle || pr.head?.ref === releaseBranch)
+                );
+                if (releasePr) {
+                  const notesMatch = (releasePr.body || "").match(/##\s*Release notes\s*([\s\S]*)/i);
+                  body = (notesMatch ? notesMatch[1] : releasePr.body || "").trim();
+                }
               }
 
               core.setOutput("is_release", "true");


### PR DESCRIPTION
## ✨ Features Updates && 🐛 Bug Fix && 🛠 Code Refactor && 📦 Dependency Update

### 📌 Description

Make manual Create GitHub Release recovery reuse the merged release PR body when a GitHub Release does not already exist. This prevents manual recovery runs from falling back to GitHub's raw generated notes and losing the categorized release notes prepared by the release PR workflow.

### 🛠 Bug Fixes

- [x] Fixed issue: manual recovery could publish uncategorized GitHub-generated notes
- [x] Other: look up the merged release PR by `release: v...` title or `release/v...` branch
- [x] Other: extract content after `## Release notes` when available

### ✅ Checklist

2. Bug Fixes:

- [x] Bug has been reproduced and verified.
- [x] Fix does not introduce new issues.

3. Code Refactor:

- [x] No breaking changes introduced.

### 📝 Steps to Reproduce (before fix)

After a release PR is merged but the GitHub Release is missing, run Create GitHub Release manually for the release version. The workflow creates the release with GitHub-generated notes instead of the release PR's categorized notes.

### 💬 Additional Notes

Automated checks run locally: `pnpm run lint`, `git diff --check`.

Self-review focus: this only affects the manual dispatch path when the release does not already exist. Existing release, tag push, and main push release paths are unchanged.

### 📸 Screenshots (if applicable)

Not applicable.
