### PR TITLE
feat(ui): refine API docs utilities

### DIFF
--- a/src/avatar-link-generator.js
+++ b/src/avatar-link-generator.js
@@ -1,0 +1,155 @@
+const form = document.querySelector('[data-avatar-link-form]')
+
+if (form instanceof HTMLFormElement) {
+  const emailInput = form.querySelector('[data-avatar-email]')
+  const sizeInput = form.querySelector('[data-avatar-size]')
+  const defaultInput = form.querySelector('[data-avatar-default]')
+  const preview = document.querySelector('[data-avatar-preview]')
+  const urlOutput = document.querySelector('[data-avatar-url]')
+  const markdownOutput = document.querySelector('[data-avatar-markdown]')
+  const htmlOutput = document.querySelector('[data-avatar-html]')
+  const status = document.querySelector('[data-avatar-status]')
+
+  const setStatus = (message) => {
+    if (status !== null) {
+      status.textContent = message
+    }
+  }
+
+  const normalizeEmail = value => value.trim().toLowerCase()
+
+  const toHex = (buffer) => {
+    return Array.from(
+      new Uint8Array(buffer),
+      byte => byte.toString(16).padStart(2, '0'),
+    ).join('')
+  }
+
+  const sha256 = async (value) => {
+    if (window.crypto?.subtle === undefined) {
+      setStatus('Web Crypto is unavailable in this browser context.')
+      return null
+    }
+
+    const encoded = new TextEncoder().encode(value)
+    return toHex(await crypto.subtle.digest('SHA-256', encoded))
+  }
+
+  const readSize = (input) => {
+    const fallback = 200
+    const min = Number.parseInt(input.min, 10) || 16
+    const max = Number.parseInt(input.max, 10) || 2048
+    const value = Number.parseInt(input.value, 10) || fallback
+    return Math.min(Math.max(value, min), max)
+  }
+
+  const buildAvatarUrl = async () => {
+    if (!(emailInput instanceof HTMLInputElement) || !(sizeInput instanceof HTMLInputElement) || !(defaultInput instanceof HTMLInputElement)) {
+      return null
+    }
+
+    const email = normalizeEmail(emailInput.value)
+    if (email.length === 0 || !emailInput.checkValidity()) {
+      return null
+    }
+
+    const hash = await sha256(email)
+    if (hash === null) {
+      return null
+    }
+
+    const size = readSize(sizeInput)
+    const fallback = defaultInput.value.trim()
+    const url = new URL(`/avatar/${hash}`, window.location.origin)
+    url.searchParams.set('s', String(size))
+    if (fallback.length > 0 && fallback !== '404') {
+      url.searchParams.set('d', fallback)
+    }
+
+    return {
+      alt: email,
+      size,
+      url: url.toString(),
+    }
+  }
+
+  const clearOutputs = () => {
+    if (preview instanceof HTMLImageElement) {
+      preview.removeAttribute('src')
+      preview.alt = 'Avatar preview'
+    }
+    if (urlOutput instanceof HTMLInputElement) {
+      urlOutput.value = ''
+    }
+    if (markdownOutput instanceof HTMLTextAreaElement) {
+      markdownOutput.value = ''
+    }
+    if (htmlOutput instanceof HTMLTextAreaElement) {
+      htmlOutput.value = ''
+    }
+  }
+
+  const update = async () => {
+    const result = await buildAvatarUrl()
+    if (result === null) {
+      clearOutputs()
+      setStatus('Enter a valid email to generate a hash-based avatar link.')
+      return
+    }
+
+    if (preview instanceof HTMLImageElement) {
+      preview.src = result.url
+      preview.alt = `Avatar preview for ${result.alt}`
+    }
+    if (urlOutput instanceof HTMLInputElement) {
+      urlOutput.value = result.url
+    }
+    if (markdownOutput instanceof HTMLTextAreaElement) {
+      markdownOutput.value = `![Avatar](${result.url})`
+    }
+    if (htmlOutput instanceof HTMLTextAreaElement) {
+      htmlOutput.value = `<img src="${result.url}" alt="Avatar" width="${result.size}" height="${result.size}">`
+    }
+    setStatus('Generated locally. The email was not sent to this Worker.')
+  }
+
+  const copyValue = async (button) => {
+    const target = button.getAttribute('data-copy-target')
+    if (target === null) {
+      return
+    }
+
+    const field = document.querySelector(target)
+    const value = field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement
+      ? field.value
+      : ''
+    if (value.length === 0) {
+      setStatus('Generate a link before copying.')
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(value)
+      setStatus('Copied to clipboard.')
+    }
+    catch {
+      setStatus('Clipboard access is unavailable. Select the field and copy manually.')
+    }
+  }
+
+  form.addEventListener('input', () => {
+    void update()
+  })
+  form.addEventListener('submit', (event) => {
+    event.preventDefault()
+    void update()
+  })
+  document.querySelectorAll('[data-copy-target]').forEach((button) => {
+    button.addEventListener('click', () => {
+      if (button instanceof HTMLButtonElement) {
+        void copyValue(button)
+      }
+    })
+  })
+  void update()
+}

--- a/src/components/api-docs.tsx
+++ b/src/components/api-docs.tsx
@@ -13,9 +13,10 @@ const Section = ({ title, children }: PropsWithChildren<{ title: string }>) => {
 
 interface ApiDocsProps {
   config: SiteConfig
+  currentYear: number
 }
 
-const ApiDocs = ({ config }: ApiDocsProps) => {
+const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
   const formatTtl = (seconds: number) => {
     if (seconds % 86400 === 0) {
       const days = seconds / 86400
@@ -224,7 +225,7 @@ const ApiDocs = ({ config }: ApiDocsProps) => {
         </ul>
       </Section>
 
-      <Footer config={config} />
+      <Footer config={config} currentYear={currentYear} />
     </main>
   )
 }

--- a/src/components/api-docs.tsx
+++ b/src/components/api-docs.tsx
@@ -87,6 +87,53 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
         </article>
       </Section>
 
+      <Section title="🔗 Generate Avatar Links">
+        <form className="link-generator" data-avatar-link-form>
+          <div className="link-generator-fields">
+            <label>
+              Email
+              <input data-avatar-email type="email" inputMode="email" autoComplete="email" placeholder="email@example.com" required />
+            </label>
+            <label>
+              Size
+              <input data-avatar-size type="number" min="16" max={config.api.maxSize} defaultValue={config.api.defaultSize} />
+            </label>
+            <label>
+              Fallback
+              <input data-avatar-default type="text" defaultValue="404" placeholder="404, mp, identicon, initials..." />
+            </label>
+          </div>
+
+          <div className="link-generator-result" aria-live="polite">
+            <img className="avatar-preview" data-avatar-preview alt="Avatar preview" width={config.api.defaultSize} height={config.api.defaultSize} />
+            <div className="generated-links">
+              <label>
+                Direct URL
+                <span className="copy-row">
+                  <input id="generated-avatar-url" data-avatar-url readOnly />
+                  <button type="button" data-copy-target="#generated-avatar-url">Copy</button>
+                </span>
+              </label>
+              <label>
+                Markdown
+                <span className="copy-row">
+                  <textarea id="generated-avatar-markdown" data-avatar-markdown readOnly rows={2} />
+                  <button type="button" data-copy-target="#generated-avatar-markdown">Copy</button>
+                </span>
+              </label>
+              <label>
+                HTML
+                <span className="copy-row">
+                  <textarea id="generated-avatar-html" data-avatar-html readOnly rows={2} />
+                  <button type="button" data-copy-target="#generated-avatar-html">Copy</button>
+                </span>
+              </label>
+            </div>
+          </div>
+          <p className="generator-status" data-avatar-status>Enter a valid email to generate a hash-based avatar link.</p>
+        </form>
+      </Section>
+
       <Section title="⚙️ Query Parameters">
         <ul>
           <li>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,10 +1,9 @@
 interface FooterProps {
   config: SiteConfig
+  currentYear: number
 }
 
-const CURRENT_YEAR = new Date().getFullYear()
-
-const Footer = ({ config }: FooterProps) => {
+const Footer = ({ config, currentYear }: FooterProps) => {
   const footerLabel = config.branding.footerText ?? config.branding.siteName
 
   return (
@@ -12,7 +11,7 @@ const Footer = ({ config }: FooterProps) => {
       <p class="footer-text">
         ©
         {' '}
-        {CURRENT_YEAR}
+        {currentYear}
         {' '}
         {config.branding.contactUrl !== undefined
           ? (

--- a/src/components/head.tsx
+++ b/src/components/head.tsx
@@ -1,4 +1,4 @@
-import { Link, ViteClient } from 'vite-ssr-components/hono'
+import { Link, Script, ViteClient } from 'vite-ssr-components/hono'
 
 interface HeadProps {
   config: SiteConfig
@@ -76,6 +76,7 @@ const Head = ({ config, meta }: HeadProps) => {
         })}
       </script>
       <ViteClient />
+      <Script src="/src/avatar-link-generator.js" />
       <Link href="/src/style.css" rel="stylesheet" />
     </head>
   )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ app.use('*', async (c, next) => {
 
 app.get('/', (c) => {
   const config = loadConfig(c.env)
-  return c.render(<ApiDocs config={config} />)
+  return c.render(<ApiDocs config={config} currentYear={new Date().getUTCFullYear()} />)
 })
 
 app.get('/robots.txt', (c) => {

--- a/src/style.css
+++ b/src/style.css
@@ -68,6 +68,109 @@ body {
   margin-bottom: 1rem;
 }
 
+.link-generator {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.link-generator label {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.link-generator input,
+.link-generator textarea {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-card);
+  color: var(--text-main);
+  font: inherit;
+  font-size: 0.95rem;
+  padding: 0.65rem 0.75rem;
+}
+
+.link-generator textarea {
+  min-height: 4.2rem;
+  resize: vertical;
+}
+
+.link-generator input:focus,
+.link-generator textarea:focus,
+.link-generator button:focus {
+  outline: 2px solid var(--color-secondary-300);
+  outline-offset: 2px;
+}
+
+.link-generator-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 8rem minmax(10rem, 0.7fr);
+  gap: 0.8rem;
+  margin-bottom: 1rem;
+}
+
+.link-generator-result {
+  display: grid;
+  grid-template-columns: 5rem minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.avatar-preview {
+  width: 5rem;
+  height: 5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-card);
+  object-fit: cover;
+}
+
+.generated-links {
+  display: grid;
+  gap: 0.8rem;
+  min-width: 0;
+}
+
+.copy-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.copy-row button {
+  border: 1px solid var(--color-secondary-500);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--color-secondary-700);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.65rem 0.85rem;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.copy-row button:hover {
+  border-color: var(--color-accent-500);
+  color: var(--color-accent-500);
+}
+
+.generator-status {
+  min-height: 1.3rem;
+  margin: 0.8rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
 code {
   background-color: #f5f5f7;
   color: #333;
@@ -136,4 +239,17 @@ ul li {
   color: var(--color-accent-500);
   text-decoration-style: dotted;
   text-underline-offset: 4px;
+}
+
+@media (max-width: 700px) {
+  .link-generator-fields,
+  .link-generator-result,
+  .copy-row {
+    grid-template-columns: 1fr;
+  }
+
+  .avatar-preview {
+    width: 5rem;
+    height: 5rem;
+  }
 }


### PR DESCRIPTION
### Description

Refines the API docs page with a small avatar link utility and fixes the footer year rendering.

### Key Changes

- Pass the current year from the request handler into the footer so the rendered copyright year stays current.
- Add a compact avatar link generator to the API docs page.
- Generate SHA-256 hash links in the browser so raw email values are not sent to the Worker.
- Output direct URL, Markdown, and HTML snippets with copy buttons.
- Keep the layout aligned with the existing docs page and responsive on narrow screens.

### Testing

- `CI=true pnpm run lint`
- `CI=true pnpm run build`
- `git diff --check`
- Browser verification on `http://localhost:5173/`:
  - footer shows `2026`
  - email input generates a hash-based `/avatar/:hash` URL
  - Markdown and HTML snippets update
  - mobile and desktop layouts have no horizontal overflow

### Review Notes

- The generator is intentionally client-side and hash-route based, so it does not require `ALLOW_RAW_EMAIL=true`.
- Subagent audit could not be started because the thread limit was reached; I completed a focused local review for privacy, layout, build entry, and accessibility basics.
