### PR TITLE
refactor(ui): refine avatar generator design

### DIFF
--- a/src/avatar-link-generator.js
+++ b/src/avatar-link-generator.js
@@ -1,14 +1,20 @@
 const form = document.querySelector('[data-avatar-link-form]')
 
 if (form instanceof HTMLFormElement) {
+  const DEBOUNCE_MS = 300
   const emailInput = form.querySelector('[data-avatar-email]')
   const sizeInput = form.querySelector('[data-avatar-size]')
   const defaultInput = form.querySelector('[data-avatar-default]')
+  const initialsField = form.querySelector('[data-avatar-initials-field]')
+  const initialsInput = form.querySelector('[data-avatar-initials]')
+  const resultPanel = document.querySelector('[data-avatar-result]')
   const preview = document.querySelector('[data-avatar-preview]')
   const urlOutput = document.querySelector('[data-avatar-url]')
   const markdownOutput = document.querySelector('[data-avatar-markdown]')
   const htmlOutput = document.querySelector('[data-avatar-html]')
   const status = document.querySelector('[data-avatar-status]')
+  let updateTimer = null
+  let updateSequence = 0
 
   const setStatus = (message) => {
     if (status !== null) {
@@ -37,14 +43,33 @@ if (form instanceof HTMLFormElement) {
 
   const readSize = (input) => {
     const fallback = 200
-    const min = Number.parseInt(input.min, 10) || 16
-    const max = Number.parseInt(input.max, 10) || 2048
+    const min = Number.parseInt(input.min ?? '', 10) || 16
+    const max = Number.parseInt(input.max ?? '', 10) || 2048
     const value = Number.parseInt(input.value, 10) || fallback
     return Math.min(Math.max(value, min), max)
   }
 
+  const getFallbackValue = () => {
+    return defaultInput instanceof HTMLInputElement || defaultInput instanceof HTMLSelectElement
+      ? defaultInput.value.trim()
+      : '404'
+  }
+
+  const setResultVisibility = (isVisible) => {
+    if (resultPanel instanceof HTMLElement) {
+      resultPanel.hidden = !isVisible
+    }
+  }
+
+  const syncInitialsField = () => {
+    const usesInitials = getFallbackValue() === 'initials'
+    if (initialsField instanceof HTMLElement) {
+      initialsField.hidden = !usesInitials
+    }
+  }
+
   const buildAvatarUrl = async () => {
-    if (!(emailInput instanceof HTMLInputElement) || !(sizeInput instanceof HTMLInputElement) || !(defaultInput instanceof HTMLInputElement)) {
+    if (!(emailInput instanceof HTMLInputElement) || !(sizeInput instanceof HTMLInputElement || sizeInput instanceof HTMLSelectElement)) {
       return null
     }
 
@@ -59,11 +84,17 @@ if (form instanceof HTMLFormElement) {
     }
 
     const size = readSize(sizeInput)
-    const fallback = defaultInput.value.trim()
+    const fallback = getFallbackValue()
     const url = new URL(`/avatar/${hash}`, window.location.origin)
     url.searchParams.set('s', String(size))
     if (fallback.length > 0 && fallback !== '404') {
       url.searchParams.set('d', fallback)
+    }
+    if (fallback === 'initials' && initialsInput instanceof HTMLInputElement) {
+      const initials = initialsInput.value.trim()
+      if (initials.length > 0) {
+        url.searchParams.set('initials', initials)
+      }
     }
 
     return {
@@ -74,6 +105,7 @@ if (form instanceof HTMLFormElement) {
   }
 
   const clearOutputs = () => {
+    setResultVisibility(false)
     if (preview instanceof HTMLImageElement) {
       preview.removeAttribute('src')
       preview.alt = 'Avatar preview'
@@ -91,13 +123,27 @@ if (form instanceof HTMLFormElement) {
   }
 
   const update = async () => {
-    const result = await buildAvatarUrl()
-    if (result === null) {
+    const sequence = ++updateSequence
+    syncInitialsField()
+
+    if (emailInput instanceof HTMLInputElement && emailInput.value.trim().length === 0) {
       clearOutputs()
-      setStatus('Enter a valid email to generate a hash-based avatar link.')
+      setStatus('Enter an email address to generate a hash-based avatar link.')
       return
     }
 
+    setStatus('Generating link...')
+    const result = await buildAvatarUrl()
+    if (sequence !== updateSequence) {
+      return
+    }
+    if (result === null) {
+      clearOutputs()
+      setStatus('Enter a valid email address.')
+      return
+    }
+
+    setResultVisibility(true)
     if (preview instanceof HTMLImageElement) {
       preview.src = result.url
       preview.alt = `Avatar preview for ${result.alt}`
@@ -113,6 +159,17 @@ if (form instanceof HTMLFormElement) {
       htmlOutput.value = `<img src="${result.url}" alt="Avatar" width="${result.size}" height="${result.size}">`
     }
     setStatus('Generated locally. The email was not sent to this Worker.')
+  }
+
+  const scheduleUpdate = () => {
+    if (updateTimer !== null) {
+      window.clearTimeout(updateTimer)
+    }
+    syncInitialsField()
+    updateTimer = window.setTimeout(() => {
+      updateTimer = null
+      void update()
+    }, DEBOUNCE_MS)
   }
 
   const copyValue = async (button) => {
@@ -139,9 +196,8 @@ if (form instanceof HTMLFormElement) {
     }
   }
 
-  form.addEventListener('input', () => {
-    void update()
-  })
+  form.addEventListener('input', scheduleUpdate)
+  form.addEventListener('change', scheduleUpdate)
   form.addEventListener('submit', (event) => {
     event.preventDefault()
     void update()
@@ -153,5 +209,6 @@ if (form instanceof HTMLFormElement) {
       }
     })
   })
-  void update()
+  syncInitialsField()
+  clearOutputs()
 }

--- a/src/components/api-docs.tsx
+++ b/src/components/api-docs.tsx
@@ -11,6 +11,19 @@ const Section = ({ title, children }: PropsWithChildren<{ title: string }>) => {
   )
 }
 
+const FALLBACK_OPTIONS = [
+  { value: '404', label: '404 response' },
+  { value: 'mp', label: 'Mystery person' },
+  { value: 'identicon', label: 'Identicon' },
+  { value: 'monsterid', label: 'Monster ID' },
+  { value: 'retro', label: 'Retro' },
+  { value: 'robohash', label: 'RoboHash' },
+  { value: 'blank', label: 'Blank image' },
+  { value: 'initials', label: 'Initials' },
+]
+
+const COMMON_AVATAR_SIZES = [64, 96, 128, 200, 256, 512]
+
 interface ApiDocsProps {
   config: SiteConfig
   currentYear: number
@@ -33,26 +46,32 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
     return `${seconds} seconds`
   }
 
+  const sizeOptions = Array.from(
+    new Set([
+      ...COMMON_AVATAR_SIZES.filter(size => size <= config.api.maxSize),
+      config.api.defaultSize,
+    ]),
+  ).sort((a, b) => a - b)
+
   return (
     <main className="api-docs" aria-label={`${config.branding.siteName} API Documentation`}>
       <header>
+        <p className="eyebrow">API Reference</p>
         <h1>
           {config.branding.siteName}
-          {' '}
-          API
         </h1>
         <p className="subtitle">
           {config.branding.siteTagline ?? 'Serve avatars from Gravatar with modern WebP/AVIF support, intelligent caching, and graceful fallback handling.'}
         </p>
       </header>
 
-      <Section title="📌 Endpoints">
+      <Section title="Endpoints">
         <article
           className="endpoint"
           aria-label="CDN maintainer's avatar endpoint"
         >
           <code>GET /avatar/me</code>
-          <p>Fetch the maintainer's avatar with no param needed.</p>
+          <p>Returns the configured maintainer avatar.</p>
         </article>
 
         <article
@@ -60,7 +79,7 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
           aria-label="Hash-based avatar endpoint"
         >
           <code>GET /avatar/:hash</code>
-          <p>Fetch avatar via precomputed MD5 or SHA-256 hash of an email address.</p>
+          <p>Returns an avatar for a precomputed MD5 or SHA-256 email hash.</p>
           <ul>
             <li>
               <strong>hash</strong>
@@ -75,19 +94,22 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
         >
           <code>GET /avatar?email=&lt;email&gt;</code>
           <p>
-            Fetch avatar via raw email (securely hashed on the server). Enable this endpoint only when you accept that email addresses can appear in URLs, logs, browser history, and intermediary proxies.
+            Resolves a raw email address after server-side normalization. Enable this endpoint only when you accept that email addresses can appear in URLs, logs, browser history, and intermediary proxies.
             {!config.api.allowRawEmail && ' Raw email lookups are disabled on this deployment.'}
           </p>
           <ul>
             <li>
               <strong>&lt;email&gt;</strong>
-              : The plain email address to resolve a Gravatar. It is trimmed and lowercased before hashing; invalid or missing values fall back to `email@example.com`.
+              : The plain email address to resolve. It is trimmed and lowercased before hashing; invalid or missing values fall back to
+              {' '}
+              <code>email@example.com</code>
+              .
             </li>
           </ul>
         </article>
       </Section>
 
-      <Section title="🔗 Generate Avatar Links">
+      <Section title="Generate Avatar Links">
         <form className="link-generator" data-avatar-link-form>
           <div className="link-generator-fields">
             <label>
@@ -96,15 +118,31 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
             </label>
             <label>
               Size
-              <input data-avatar-size type="number" min="16" max={config.api.maxSize} defaultValue={config.api.defaultSize} />
+              <select data-avatar-size>
+                {sizeOptions.map(size => (
+                  <option key={size} value={String(size)} selected={size === config.api.defaultSize}>
+                    {size}
+                    {' '}
+                    px
+                  </option>
+                ))}
+              </select>
             </label>
             <label>
               Fallback
-              <input data-avatar-default type="text" defaultValue="404" placeholder="404, mp, identicon, initials..." />
+              <select data-avatar-default>
+                {FALLBACK_OPTIONS.map(option => (
+                  <option key={option.value} value={option.value} selected={option.value === '404'}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+            <label data-avatar-initials-field hidden>
+              Initials
+              <input data-avatar-initials type="text" inputMode="text" maxLength={4} placeholder="ZA" />
             </label>
           </div>
 
-          <div className="link-generator-result" aria-live="polite">
+          <div className="link-generator-result" data-avatar-result aria-live="polite" hidden>
             <img className="avatar-preview" data-avatar-preview alt="Avatar preview" width={config.api.defaultSize} height={config.api.defaultSize} hidden />
             <div className="generated-links">
               <label>
@@ -130,11 +168,11 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
               </label>
             </div>
           </div>
-          <p className="generator-status" data-avatar-status>Enter a valid email to generate a hash-based avatar link.</p>
+          <p className="generator-status" data-avatar-status>Enter an email address to generate a hash-based avatar link.</p>
         </form>
       </Section>
 
-      <Section title="⚙️ Query Parameters">
+      <Section title="Query Parameters">
         <ul>
           <li>
             <code>s=</code>
@@ -144,6 +182,7 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
             {' '}
             <b>
               (default:
+              {' '}
               {config.api.defaultSize}
               )
             </b>
@@ -163,21 +202,21 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
           <li>
             <code>initials=</code>
             {' '}
-            <b>(Only works when you set default to initials)</b>
+            <b>(requires default=initials)</b>
             <br />
             Fallback image using the initials you provide. Only applies when the default option is set to initials.
           </li>
           <li>
             <code>name=</code>
             {' '}
-            <b>(Only works when you set default to initials)</b>
+            <b>(requires default=initials)</b>
             <br />
             Fallback image using initials extracted from the provided name. Only applies when the default option is set to initials.
           </li>
         </ul>
       </Section>
 
-      <Section title="🎨 Format Negotiation">
+      <Section title="Format Negotiation">
         <p>
           Avatars are automatically converted to
           {' '}
@@ -202,7 +241,7 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
         </pre>
       </Section>
 
-      <Section title="📦 Caching">
+      <Section title="Caching">
         <ul>
           <li>
             <b>200 OK</b>
@@ -243,7 +282,7 @@ const ApiDocs = ({ config, currentYear }: ApiDocsProps) => {
         </ul>
       </Section>
 
-      <Section title="🧪 Example Requests">
+      <Section title="Example Requests">
         <ul>
           <li>
             Request with MD5 hash and size 128:

--- a/src/style.css
+++ b/src/style.css
@@ -1,29 +1,19 @@
 :root {
-  /* Primary - Sakura */
-  --color-primary-300: #ff9fb2;
-  --color-primary-500: #f83b69;
-  --color-primary-700: #c20e47;
-
-  /* Secondary - Sora */
-  --color-secondary-300: #91c7e0;
-  --color-secondary-500: #3b95bc;
-  --color-secondary-700: #246080;
-
-  /* Accent - Midori */
-  --color-accent-300: #81e6d9;
-  --color-accent-500: #1fada2;
-
-  /* Text */
-  --text-main: #333;
-  --text-muted: #666;
+  --color-focus: #2f86a6;
+  --color-link: #236f88;
+  --color-link-hover: #16576c;
+  --text-main: #202428;
+  --text-muted: #66717b;
   --text-light: #fafafa;
-
-  --bg-surface: #fafafa;
+  --bg-surface: #f7f8f8;
   --bg-card: #fff;
-  --border-color: #ddd;
+  --bg-muted: #f1f3f4;
+  --border-color: #d9dee2;
+  --border-strong: #b8c2ca;
 }
 
 body {
+  margin: 0;
   font-family: 'Inter', 'Roboto', 'Helvetica Neue', 'Segoe UI', 'Ubuntu', 'DejaVu Sans', 'Noto Sans', Arial, sans-serif;
   font-optical-sizing: auto;
   font-style: normal;
@@ -32,46 +22,65 @@ body {
 }
 
 .api-docs {
-  max-width: 800px;
-  margin: 2rem auto;
-  padding: 2rem;
-  background: var(--bg-surface);
-  border-radius: 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 3rem clamp(1rem, 4vw, 2.5rem);
 }
 
 .api-docs h1 {
-  font-size: 2.5rem;
+  font-size: 2.25rem;
+  line-height: 1.1;
   margin-bottom: 0.5rem;
+}
+
+.api-docs header {
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+}
+
+.eyebrow {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
 }
 
 .api-docs .subtitle {
   font-size: 1.1rem;
   color: var(--text-muted);
-  margin-bottom: 2rem;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 56rem;
 }
 
 .api-docs section {
-  margin-bottom: 2.5rem;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
 }
 
 .api-docs h2 {
-  font-size: 1.5rem;
-  margin-bottom: 0.8rem;
+  font-size: 1.25rem;
+  line-height: 1.25;
+  margin-bottom: 1rem;
 }
 
 .endpoint {
   background: var(--bg-card);
   border: 1px solid var(--border-color);
   padding: 1rem;
-  border-radius: 8px;
+  border-radius: 6px;
   margin-bottom: 1rem;
 }
 
 .link-generator {
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 1rem;
+  background: var(--bg-card);
 }
 
 .link-generator label {
@@ -82,7 +91,12 @@ body {
   font-weight: 600;
 }
 
+.link-generator [hidden] {
+  display: none;
+}
+
 .link-generator input,
+.link-generator select,
 .link-generator textarea {
   box-sizing: border-box;
   width: 100%;
@@ -95,38 +109,61 @@ body {
   padding: 0.65rem 0.75rem;
 }
 
+.link-generator select {
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+    linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) 50%,
+    calc(100% - 13px) 50%;
+  background-size:
+    5px 5px,
+    5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 2.2rem;
+}
+
 .link-generator textarea {
   min-height: 4.2rem;
   resize: vertical;
 }
 
 .link-generator input:focus,
+.link-generator select:focus,
 .link-generator textarea:focus,
 .link-generator button:focus {
-  outline: 2px solid var(--color-secondary-300);
+  border-color: var(--color-focus);
+  outline: 2px solid rgba(47, 134, 166, 0.22);
   outline-offset: 2px;
 }
 
 .link-generator-fields {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 8rem minmax(10rem, 0.7fr);
+  grid-template-columns: minmax(16rem, 1fr) 8.5rem 12rem minmax(7rem, 0.55fr);
   gap: 0.8rem;
   margin-bottom: 1rem;
 }
 
 .link-generator-result {
+  border-top: 1px solid var(--border-color);
   display: grid;
   grid-template-columns: 5rem minmax(0, 1fr);
   gap: 1rem;
   align-items: start;
+  padding-top: 1rem;
+}
+
+.link-generator-result[hidden] {
+  display: none;
 }
 
 .avatar-preview {
   width: 5rem;
   height: 5rem;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--bg-card);
+  border-radius: 6px;
+  background: var(--bg-muted);
   object-fit: cover;
 }
 
@@ -148,10 +185,10 @@ body {
 }
 
 .copy-row button {
-  border: 1px solid var(--color-secondary-500);
+  border: 1px solid var(--border-strong);
   border-radius: 6px;
   background: #fff;
-  color: var(--color-secondary-700);
+  color: var(--text-main);
   cursor: pointer;
   font: inherit;
   font-size: 0.9rem;
@@ -164,8 +201,8 @@ body {
 }
 
 .copy-row button:hover {
-  border-color: var(--color-accent-500);
-  color: var(--color-accent-500);
+  border-color: var(--color-link);
+  color: var(--color-link);
 }
 
 .generator-status {
@@ -176,8 +213,8 @@ body {
 }
 
 code {
-  background-color: #f5f5f7;
-  color: #333;
+  background-color: var(--bg-muted);
+  color: var(--text-main);
   font-family: 'JetBrains Mono', 'Fira Code', 'Menlo', 'Consolas', 'Courier New', monospace;
   font-size: 0.95rem;
   padding: 2px 6px;
@@ -186,16 +223,16 @@ code {
 }
 
 pre {
-  background-color: #2d2d2d;
-  color: var(--text-light);
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  color: var(--text-main);
   font-family: 'JetBrains Mono', 'Fira Code', 'Menlo', 'Consolas', 'Courier New', monospace;
   font-size: 0.9rem;
   padding: 1rem 1.2rem;
-  border-radius: 10px;
+  border-radius: 6px;
   overflow-x: auto;
   margin-top: 1rem;
   line-height: 1.5;
-  box-shadow: inset 0 0 0 1px #444;
 }
 
 pre code {
@@ -217,10 +254,8 @@ ul li {
 
 .footer {
   text-align: center;
-  margin-top: 4rem;
+  margin-top: 3rem;
   font-size: 0.9rem;
-  border-top: 1px solid var(--border-color);
-  padding-top: 1.5rem;
   color: var(--text-muted);
 }
 
@@ -229,7 +264,7 @@ ul li {
 }
 
 .footer-link {
-  color: var(--color-secondary-500);
+  color: var(--color-link);
   text-decoration: underline;
   text-decoration-style: dashed;
   text-underline-offset: 2px;
@@ -240,7 +275,7 @@ ul li {
 
 .footer-link:hover,
 .footer-link:focus {
-  color: var(--color-accent-500);
+  color: var(--color-link-hover);
   text-decoration-style: dotted;
   text-underline-offset: 4px;
 }
@@ -250,6 +285,10 @@ ul li {
   .link-generator-result,
   .copy-row {
     grid-template-columns: 1fr;
+  }
+
+  .api-docs {
+    padding-top: 1.5rem;
   }
 
   .avatar-preview {


### PR DESCRIPTION
## Description

Refines the API docs page and avatar link generator so the first visit, editing flow, and fallback controls feel more intentional.

## Feature Changes

- [x] UI/UX improvement
- [x] Other: generator control polish

## Refactor Changes

- [x] Improve maintainability

## Bug Fixes

- [x] Fixed issue: empty generator output no longer shows blank URL/Markdown/HTML fields before an email is entered.

## Checklist

1. Feature Updates:

- [x] Code follows project coding style.
- [x] Tested in a Hono environment.
- [x] Relevant documentation is updated.

2. Bug Fixes:

- [x] Bug has been reproduced and verified.
- [x] Fix does not introduce new issues.
- [ ] Added necessary tests.

3. Code Refactor:

- [x] No breaking changes introduced.
- [ ] Performance improvement validated.
- [x] Documentation updated if necessary.

## Additional Notes

- The generator result area now stays hidden until a valid email generates a link.
- Email edits are debounced, and stale async hash results are ignored.
- Size and fallback controls use selects for common values, with an initials field shown only when needed.
- The API docs page uses a quieter reference layout, plain section headings, lighter code blocks, and more direct copy.

## Testing

- `CI=true pnpm exec eslint src/components/api-docs.tsx src/avatar-link-generator.js src/style.css`
- `CI=true pnpm run lint`
- `WRANGLER_LOG_PATH=.wrangler/logs CI=true pnpm run build`
- `git diff --check`
- Playwright verification at `http://127.0.0.1:5175/`:
  - Initial state hides generated output, preview image, and initials field.
  - Size and fallback dropdowns generate a hash-based URL with `s=128&d=identicon`.
  - Rapid email edits keep the previous result visible during debounce and update the preview once.
  - Initials fallback reveals the initials input and appends `initials=ZA`.
  - Mobile viewport `390x844` has no horizontal overflow and no visible broken images.

## Screenshots

Desktop and mobile screenshots were captured during local Playwright verification.
